### PR TITLE
basepath

### DIFF
--- a/basis.cpp
+++ b/basis.cpp
@@ -481,6 +481,32 @@ bool CBasis::SetParameter(const yaya::string_t &cmd, const yaya::string_t &param
 		}
 		return true;
 	}
+	// basepath
+	if ( cmd.compare(L"basepath") == 0 ) {
+		if(!_wchdir(param.c_str())){//successful
+			#if defined(WIN32) || defined(_WIN32_WCE)
+			if(param[1]==L':')
+			#elif defined(POSIX)
+			if(param[0]==L'/')
+			#endif
+				load_path = param;
+			else
+				load_path += param;
+
+			//最後が\でも/でもなければ足す
+			if (load_path.length() == 0 || ( (load_path[load_path.length()-1] != L'/') && (load_path[load_path.length()-1] != L'\\') ) ) {
+				#if defined(WIN32) || defined(_WIN32_WCE)
+				load_path += L"\\";
+				#elif defined(POSIX)
+				load_path += L"/";
+				#endif
+			}
+			return true;
+		}
+		else{
+			return false;
+		}
+	}
 	// iolog
 	if ( cmd.compare(L"iolog") == 0 ) {
 		iolog = param.compare(L"off") != 0;


### PR DESCRIPTION
Users are allowed to put yaya related files into a subfolder, but yaya still behaves as if it is in the ghost root directory