### PR TITLE
EXECUTEGLOBALDEFINE

### DIFF
--- a/parser0.h
+++ b/parser0.h
@@ -65,7 +65,7 @@ protected:
 	char	LoadDictionary1(const yaya::string_t& filename, std::vector<CDefine>& gdefines, int charset);
 	char	GetPreProcess(yaya::string_t& str, std::vector<CDefine>& defines, std::vector<CDefine>& gdefines, const yaya::string_t& dicfilename,
 					int linecount);
-public://EXECUTEGLOBALDEFINE
+public://PREPROCESSGLOBALDEFINE
 	void	ExecDefinePreProcess(yaya::string_t &str, const std::vector<CDefine>& defines);
 protected:
 	void	ExecInternalPreProcess(yaya::string_t &str,const yaya::string_t &file,int line);

--- a/parser0.h
+++ b/parser0.h
@@ -65,8 +65,9 @@ protected:
 	char	LoadDictionary1(const yaya::string_t& filename, std::vector<CDefine>& gdefines, int charset);
 	char	GetPreProcess(yaya::string_t& str, std::vector<CDefine>& defines, std::vector<CDefine>& gdefines, const yaya::string_t& dicfilename,
 					int linecount);
-
+public://EXECUTEGLOBALDEFINE
 	void	ExecDefinePreProcess(yaya::string_t &str, const std::vector<CDefine>& defines);
+protected:
 	void	ExecInternalPreProcess(yaya::string_t &str,const yaya::string_t &file,int line);
 
 	char	IsCipheredDic(const yaya::string_t& filename);

--- a/sysfunc.cpp
+++ b/sysfunc.cpp
@@ -91,7 +91,7 @@ extern "C" {
 #endif
 #endif
 
-#define	SYSFUNC_NUM					141 //システム関数の全数
+#define	SYSFUNC_NUM					142 //システム関数の全数
 #define	SYSFUNC_HIS					61 //EmBeD_HiStOrY の位置（0start）
 
 static const wchar_t sysfunc[SYSFUNC_NUM][32] = {
@@ -294,6 +294,7 @@ static const wchar_t sysfunc[SYSFUNC_NUM][32] = {
 	L"DICLOAD",
 	L"GETSYSTEMFUNCLIST",
 	L"GETFUNCINFO",
+	L"EXECUTEGLOBALDEFINE",
 };
 
 //このグローバル変数はマルチインスタンスでも共通
@@ -703,6 +704,8 @@ CValue	CSystemFunction::Execute(int index, const CValue &arg, const std::vector<
 		return GETSYSTEMFUNCLIST(arg, d, l);
 	case 140:
 		return GETFUNCINFO(arg, d, l);
+	case 141:
+		return EXECUTEGLOBALDEFINE(arg, d, l);
 	default:
 		vm.logger().Error(E_E, 49, d, l);
 		return CValue(F_TAG_NOP, 0/*dmy*/);
@@ -3198,6 +3201,30 @@ CValue CSystemFunction::GETFUNCINFO(const CValue &arg, yaya::string_t &d, int &l
 	result.array().push_back(CValueSub((int)it->GetLineNumEnd()));
 
 	return result;
+}
+
+/* -----------------------------------------------------------------------
+ *  関数名  ：  CSystemFunction::EXECUTEGLOBALDEFINE
+ * -----------------------------------------------------------------------
+ */
+CValue CSystemFunction::EXECUTEGLOBALDEFINE(const CValue &arg, yaya::string_t &d, int &l)
+{
+	if (!arg.array_size()) {
+		vm.logger().Error(E_W, 8, L"EXECUTEGLOBALDEFINE", d, l);
+		SetError(8);
+		return CValue(-1);
+	}
+
+	if (!arg.array()[0].IsString()) {
+		vm.logger().Error(E_W, 9, L"EXECUTEGLOBALDEFINE", d, l);
+		SetError(9);
+		return CValue(-1);
+	}
+
+	yaya::string_t aret = arg.array()[0].GetValueString();
+	vm.parser0().ExecDefinePreProcess(aret,vm.gdefines());
+
+	return CValue(aret);
 }
 /* -----------------------------------------------------------------------
  *  関数名  ：  CSystemFunction::FSIZE

--- a/sysfunc.cpp
+++ b/sysfunc.cpp
@@ -294,7 +294,7 @@ static const wchar_t sysfunc[SYSFUNC_NUM][32] = {
 	L"DICLOAD",
 	L"GETSYSTEMFUNCLIST",
 	L"GETFUNCINFO",
-	L"EXECUTEGLOBALDEFINE",
+	L"PREPROCESSGLOBALDEFINE",
 };
 
 //このグローバル変数はマルチインスタンスでも共通
@@ -705,7 +705,7 @@ CValue	CSystemFunction::Execute(int index, const CValue &arg, const std::vector<
 	case 140:
 		return GETFUNCINFO(arg, d, l);
 	case 141:
-		return EXECUTEGLOBALDEFINE(arg, d, l);
+		return PREPROCESSGLOBALDEFINE(arg, d, l);
 	default:
 		vm.logger().Error(E_E, 49, d, l);
 		return CValue(F_TAG_NOP, 0/*dmy*/);
@@ -3204,19 +3204,19 @@ CValue CSystemFunction::GETFUNCINFO(const CValue &arg, yaya::string_t &d, int &l
 }
 
 /* -----------------------------------------------------------------------
- *  関数名  ：  CSystemFunction::EXECUTEGLOBALDEFINE
+ *  関数名  ：  CSystemFunction::PREPROCESSGLOBALDEFINE
  * -----------------------------------------------------------------------
  */
-CValue CSystemFunction::EXECUTEGLOBALDEFINE(const CValue &arg, yaya::string_t &d, int &l)
+CValue CSystemFunction::PREPROCESSGLOBALDEFINE(const CValue &arg, yaya::string_t &d, int &l)
 {
 	if (!arg.array_size()) {
-		vm.logger().Error(E_W, 8, L"EXECUTEGLOBALDEFINE", d, l);
+		vm.logger().Error(E_W, 8, L"PREPROCESSGLOBALDEFINE", d, l);
 		SetError(8);
 		return CValue(-1);
 	}
 
 	if (!arg.array()[0].IsString()) {
-		vm.logger().Error(E_W, 9, L"EXECUTEGLOBALDEFINE", d, l);
+		vm.logger().Error(E_W, 9, L"PREPROCESSGLOBALDEFINE", d, l);
 		SetError(9);
 		return CValue(-1);
 	}

--- a/sysfunc.h
+++ b/sysfunc.h
@@ -245,6 +245,7 @@ protected:
 
 	CValue	DICLOAD(const CValue &arg, yaya::string_t &d, int &l);
 	CValue	GETFUNCINFO(const CValue &arg, yaya::string_t &d, int &l);
+	CValue	EXECUTEGLOBALDEFINE(const CValue &arg, yaya::string_t &d, int &l);
 
 	CValue	RE_SPLIT_CORE(const CValue &arg, yaya::string_t &d, int &l, const yaya::char_t *fncname, size_t num);
 

--- a/sysfunc.h
+++ b/sysfunc.h
@@ -245,7 +245,7 @@ protected:
 
 	CValue	DICLOAD(const CValue &arg, yaya::string_t &d, int &l);
 	CValue	GETFUNCINFO(const CValue &arg, yaya::string_t &d, int &l);
-	CValue	EXECUTEGLOBALDEFINE(const CValue &arg, yaya::string_t &d, int &l);
+	CValue	PREPROCESSGLOBALDEFINE(const CValue &arg, yaya::string_t &d, int &l);
 
 	CValue	RE_SPLIT_CORE(const CValue &arg, yaya::string_t &d, int &l, const yaya::char_t *fncname, size_t num);
 


### PR DESCRIPTION
```
EVAL_EX{
	EVAL(EXECUTEGLOBALDEFINE(_argv))
}
```
You know, one of my common development methods is to drag sakura script or yaya expression to my ghost, but she has a lot of global define, `DATA_PATH`、`SOUND_PATH`、`IMG_PATH`、etc, there could be dozens.
Now with this function, I can add the function of asking whether to handle global definition when executing expression or sakura script.