### PR TITLE
fix for SETTAMAHWND

### DIFF
--- a/basis.cpp
+++ b/basis.cpp
@@ -194,6 +194,7 @@ void	CBasis::SetPath(yaya::global_t h, int len)
 void	CBasis::SetLogRcvWnd(long hwnd)
 {
 	hlogrcvWnd = (HWND)hwnd;
+	vm.logger().Start(logpath, output_charset, hlogrcvWnd, iolog);
 }
 #endif
 


### PR DESCRIPTION
```
On_yatamaOpen{
	SETTAMAHWND(reference0)
	SHIORI_FW.Make_X_SSTP_PassThru('Tittle','some tittle')
	//SHIORI_FW.Make_X_SSTP_PassThru('Icon',GetSelfIconFullPath)
	'yatama opened'
}
On_yatamaExit{
	'yatama ended'
	SETTAMAHWND(0)
}
```