### PR TITLE
fixed a bug where the hwnd sent by tama.exe was not saved

### DIFF
--- a/aya5.cpp
+++ b/aya5.cpp
@@ -30,6 +30,7 @@ static std::vector<CAyaVMWrapper*> vm;
 static yaya::string_t modulename;
 static std::vector<void (*)(const yaya::char_t *str, int mode, int id)> loghandler_list;
 static size_t id_now=0;
+static long logsend_hwnd = 0;
 
 //////////DEBUG/////////////////////////
 #ifdef _WINDOWS
@@ -47,6 +48,11 @@ private:
 public:
 	CAyaVMWrapper(const yaya::string_t &path, yaya::global_t h, long len) {
 		vm = new CAyaVM();
+
+		if (logsend_hwnd != 0) {
+			SetLogRcvWnd(logsend_hwnd);
+			logsend_hwnd = 0;
+		}
 
 		vm->logger().Set_loghandler(loghandler_list[id_now]);
 
@@ -365,6 +371,9 @@ extern "C" DLLEXPORT BOOL_TYPE FUNCATTRIB logsend(long hwnd)
 	}
 	else if ( vm.size() >= 2 && vm[1] ) {
 		vm[1]->SetLogRcvWnd(hwnd);
+	}
+	else {
+		logsend_hwnd = hwnd;
 	}
 
 	return TRUE;


### PR DESCRIPTION
# バグ内容

[バーチャルビールかけ](http://ms.shillest.net/yaya_as.xhtml)のYAYAをTc532-1からTc569-3に差し替えると[玉](http://umeici.onjn.jp/)にドラッグ＆ドロップしても起動しなくなります。

yaya.txtには以下の記述があります。

```iolog, off```

しかし[文屋(AYAYA)](http://emily.shillest.net/ayaya/?%E3%83%9E%E3%83%8B%E3%83%A5%E3%82%A2%E3%83%AB/%E6%96%87%E6%B3%95/1.%E5%9F%BA%E7%A4%8E%E8%A8%AD%E5%AE%9A#pb05622c)によれば

> off指定としても、玉にドラッグ＆ドロップして起動する使い方をした場合は強制的にonになります。

とあります。

# 原因

[Jun 29, 2011 AyaVMマルチインスタンス対応](https://github.com/ponapalt/yaya-shiori/commit/33637d7837e8c2b9a2710cdadb816b7dbf478cf0)

loadで初めてvm[0]が作成されるが
tama.exeはloadより先にlogsendを投げてよこすため
[aya5.cpp](https://github.com/ponapalt/yaya-shiori/blob/500/aya5.cpp)内

```
	if ( vm[0] ) {
		vm[0]->basis().SetLogRcvWnd(hwnd);
	}
	else if ( vm.size() >= 2 && vm[1] ) {
		vm[1]->basis().SetLogRcvWnd(hwnd);
	}
```

を素通りしてSetLogRcvWndが処理されない
そのためtamaのhwndが保存されず
[log.cpp](https://github.com/ponapalt/yaya-shiori/blob/500/log.cpp)内

```
	if(hw || loghandler) { //hwがある＝玉からの呼び出しなので強制ON、ファイル無効
		path = L"";
	}
	else if (!il) {
		enable = 0;
		return;
	}
```

でhwが無いためelse ifに来て```iolog, off```が設定されているとtama.exeが起動しているにもかかわらず強制ONまで行かず終了する
※```iolog, on```（デフォルト）の場合は以降のGetCheckerWnd()により自力でtamaを探して続行される

# 修正内容

logsendで受け取ったhwndを一旦グローバル変数logsend_hwndに保存し、
load時にあらためてhwndをセットし直すようにした。
※C++よくわからないのでいい感じに修正してもらえるとありがたいです…。

# 追伸

報告者は当時YAYAを差し替えた際に玉が使えなくなる当該事象に気付きBTSに報告したものの、
バグレポートスキルが未熟であったため上手くお伝えすることができず修正には至りませんでした。
10年越しのリベンジとしてここに報告いたします。
