### PR TITLE
freebsdでコンパイルが通らない問題の修正

### DIFF
--- a/aya5.cpp
+++ b/aya5.cpp
@@ -335,7 +335,7 @@ extern "C" DLLEXPORT yaya::global_t FUNCATTRIB multi_request(long id, yaya::glob
 		return vm[0]->IsSuppress()||vm[0]->IsEmergency();
 	}
 	else {
-		return NULL;
+		return 0;
 	}
 }
 
@@ -349,7 +349,7 @@ extern "C" DLLEXPORT BOOL_TYPE FUNCATTRIB multi_CI_check_failed(long id)//?
 		return vm[id]->IsSuppress()||vm[id]->IsEmergency();
 	}
 	else {
-		return NULL;
+		return 0;
 	}
 }
 

--- a/deelx.h
+++ b/deelx.h
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <string.h>
 #include <stdlib.h>
+#include <cstddef>
 
 extern "C" {
 typedef int (*POSIX_FUNC)(int);

--- a/globaldef.h
+++ b/globaldef.h
@@ -18,6 +18,14 @@
 #ifndef _MSVC_LANG
 //C++11 or older
 
+#if __cplusplus >= 201103L
+
+#include <memory>
+
+#define std_shared_ptr  std::shared_ptr
+#define std_make_shared std::make_shared
+
+#else
 
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
@@ -26,6 +34,8 @@
 #define std_make_shared  boost::make_shared
 
 #define nullptr 0
+
+#endif // C++11
 
 #else
 

--- a/globaldef.h
+++ b/globaldef.h
@@ -25,6 +25,10 @@
 #define std_shared_ptr  std::shared_ptr
 #define std_make_shared std::make_shared
 
+// freebsdでdefine nullptr 0を行うと
+// aya5.cpp:L507のloghandler_list.emplace_back(nullptr)で
+// 型不一致のエラーが出るのでdefineしない。
+
 #else
 
 #include <boost/shared_ptr.hpp>

--- a/log.cpp
+++ b/log.cpp
@@ -5,6 +5,8 @@
 // written by umeici. 2004
 // 
 
+#include <algorithm>
+
 #if defined(WIN32) || defined(_WIN32_WCE)
 # include "stdafx.h"
 #endif

--- a/makefile.freebsd
+++ b/makefile.freebsd
@@ -93,6 +93,11 @@ $(LIBAYA5): $(LIBAYA5_OBJ)
 	$(LD) -o $@ $(LIBAYA5_OBJ) $(LDFLAGS) $(LD_ADD)
 #	$(STRIP) -x $@
 
+.c.o:
+	@iconv --from-code=CP932 --to-code=UTF-8 -c $< > $*.tmp.cpp
+	$(CXX) $(CXXFLAGS) $(CXXFLAGS_ADD) -o $@ -c $*.tmp.cpp
+	@rm $*.tmp.cpp
+
 .cpp.o:
 	@iconv --from-code=CP932 --to-code=UTF-8 -c $< > $*.tmp.cpp
 	$(CXX) $(CXXFLAGS) $(CXXFLAGS_ADD) -o $@ -c $*.tmp.cpp

--- a/makefile.freebsd
+++ b/makefile.freebsd
@@ -1,8 +1,8 @@
 # -*- makefile -*-
 
 # 使用するツール類の設定
-CXX = g++
-LD = g++
+CXX = clang++
+LD = clang++
 STRIP = strip
 MKDEP = mkdep
 

--- a/makefile.freebsd
+++ b/makefile.freebsd
@@ -14,8 +14,11 @@ MKDEP = mkdep
 DYLIB_NAME_PREFIX = lib
 DYLIB_NAME_POSTFIX = .so
 
+# C++11に対応していない場合はboostの指定をしてください。
+
 # boostの場所を指定。
 BOOST_INCLUDES = /usr/local/include
+
 # libboost_regex.aの場所を設定。
 BOOST_LINK = /usr/local/lib
 
@@ -29,10 +32,15 @@ BOOST_LINK = /usr/local/lib
 CXXFLAGS = -O3 -Wall -fPIC
 LDFLAGS = -shared
 
-################## これより下は弄らなくてもコンパイル出来ます ##################
+# C++11に対応していない場合は下をコメントアウトしてください。
 
 CXXFLAGS_ADD = -DPOSIX -I. -I$(BOOST_INCLUDES)
+CXXFLAGS_ADD = -DPOSIX -I.
+
 LD_ADD = -lboost_regex -L$(BOOST_LINK)
+LD_ADD =
+
+################## これより下は弄らなくてもコンパイル出来ます ##################
 
 LIBAYA5_OBJ = \
 	aya5.o \

--- a/makefile.freebsd
+++ b/makefile.freebsd
@@ -26,7 +26,7 @@ BOOST_LINK = /usr/local/lib
 # 追加するフラグ。
 # CXXFLAGSは必要無ければ空でも良いが、LDFLAGSはdlopen可能なライブラリを
 # 作れる設定にしなければならない。darwinなら-bundle、LinuxやBSDなら-shared。
-CXXFLAGS = -O3 -Wall
+CXXFLAGS = -O3 -Wall -fPIC
 LDFLAGS = -shared
 
 ################## これより下は弄らなくてもコンパイル出来ます ##################

--- a/makefile.freebsd
+++ b/makefile.freebsd
@@ -62,6 +62,7 @@ LIBAYA5_OBJ = \
 	logexcode.o \
 	manifest.o \
 	md5c.o \
+	messages.o \
 	misc.o \
 	mt19937ar.o \
 	parser0.o \
@@ -71,6 +72,7 @@ LIBAYA5_OBJ = \
 	sysfunc.o \
 	value.o \
 	valuesub.o \
+	variable.o \
 	wsex.o \
 	posix_utils.o
 


### PR DESCRIPTION
- makefile.freebsdの使用するコンパイラやCXXFLAGSを修正
- コンパイルに必要なヘッダがincludeされていなかったので追加
- 戻り値の型がBOOL_TYPEなのにNULLを返していた部分を0を返すようにした

最後のは0よりfalseを返す方が意味が汲み取りやすくていいかもしれません。

一応Windows11でもコンパイルが通るのは確認しました。
機能的に弄った部分は無いので動作も問題ない…はずです。