### PR TITLE
特定条件下でクラッシュしていたのを修正

### DIFF
--- a/function.cpp
+++ b/function.cpp
@@ -744,9 +744,19 @@ const CValue& CFunction::GetValueRefForCalc(CCell &cell, CStatement &st, CLocalV
 		return cell.ansv();
 	}
 	case F_TAG_VARIABLE:
-		return pvm->variable().GetPtr(cell.index)->call_watcher(*pvm,cell.ansv());
+		if (pvm->variable().GetPtr(cell.index) != NULL) {
+			return pvm->variable().GetPtr(cell.index)->call_watcher(*pvm,cell.ansv());
+		}
+		else {
+			return emptyvalue;
+		}
 	case F_TAG_LOCALVARIABLE:
-		return lvar.GetPtr(cell.name)->call_watcher(*pvm,cell.ansv());
+		if (lvar.GetPtr(cell.name) != NULL) {
+			return lvar.GetPtr(cell.name)->call_watcher(*pvm,cell.ansv());
+		}
+		else {
+			return emptyvalue;
+		}
 	default:
 		pvm->logger().Error(E_E, 16, dicfilename, st.linecount);
 		return emptyvalue;

--- a/variable.cpp
+++ b/variable.cpp
@@ -4,8 +4,6 @@
 #include "ayavm.h"
 
 const CValue& CVariable::call_watcher(CAyaVM&vm,CValue& save) {
-	if (!this)
-		return emptyvalue;
 	if (watcher.size()) {
 		ptrdiff_t index = vm.function_exec().GetFunctionIndexFromName(watcher);
 


### PR DESCRIPTION
- nullポインタ経由で関数呼び出しが行われていた
- 呼ばれた関数で、thisがnullの時の処理( if (!this) )が記述されていた
- thisはnon-nullとされている(nullポインタの場合は未定義動作)
- non-nullならif (!this)は常にfalseなので最適化を行うと当該処理は削除される

人人人人人人
＞ ぬるぽ ＜
^Y^Y^Y^Y^Y

となったので関数の外でnullチェックを行うように修正しました。

POSIX用にビルドしたlibaya5.soがShift_JISな辞書を読み込むとnullになるようなので
そちらを修正すべきかもしれませんが、どこを弄れば良いかさっぱりです。